### PR TITLE
Add gameinfo to player state

### DIFF
--- a/steam/containers/Player.js
+++ b/steam/containers/Player.js
@@ -17,6 +17,9 @@ module.exports = (function(undefined){
     this.personaStateFlags        = player.personastateflags ? player.personastateflags : undefined;
     this.countryCode              = player.loccountrycode;
     this.stateCode                = player.locstatecode;
+    // Optional fields returned if user is in game and has public profile
+    this.gameid                   = player.gameid;
+    this.gameextrainfo            = player.gameextrainfo;
   }
 
   Player.prototype.convertPersonaState = function convertPersonaState(personaState) {


### PR DESCRIPTION
When user is in a game, extra state is returned on the player object - here is an example response, unimportant crap removed for conciseness:

```
{
    "response": {
        "players": [
            {
                "steamid": "{redacted}",
                "communityvisibilitystate": 3,
                "profilestate": 1,
                "personaname": "{redacted}",
                "lastlogoff": {redacted},
                "profileurl": "{redacted}/",
                "avatar": "{redacted}",
                "avatarmedium": "{redacted}",
                "avatarfull": "{redacted}g",
                "personastate": 3,
                "primaryclanid": "{redacted}",
                "timecreated": {redacted},
                "personastateflags": 0,
                "gameextrainfo": "Spelunky",
                "gameid": "239350",
                "loccountrycode": "AU"
            }
        ]

    }
}
```
