### PR TITLE
Fix silent error when steamId is set larger than `MAX_SAFE_INTEGER`

### DIFF
--- a/specs/ClientSpec.js
+++ b/specs/ClientSpec.js
@@ -1,7 +1,7 @@
 var api = require('../steam/api');
 describe('Client Specs / ', function(){
   jasmine.getEnv().defaultTimeoutInterval = 30000;
-  
+
   it('Should squawk if no steam api', function(){
     oldEnv = process.env;
     process.env = {};
@@ -17,5 +17,12 @@ describe('Client Specs / ', function(){
   it('Should squawk if no arguments are found in setupService', function(){
     var client = new api.Client('this-was-set');
     expect(function(){ client.setupService(); }).toThrow(new Error("arguments must be defined"));
+  });
+
+  it('Should squawk when SteamID is trying to set as a number > MAX_SAFE', function(){
+    var client = new api.Client('this-was-set');
+
+    expect(function(){ client.setSteamId(99007199254740991); })
+        .toThrow(new Error('SteamId should be a string when larger than MAX_SAFE_INTEGER 9007199254740991'));
   });
 });

--- a/specs/ClientSpec.js
+++ b/specs/ClientSpec.js
@@ -23,6 +23,6 @@ describe('Client Specs / ', function(){
     var client = new api.Client('this-was-set');
 
     expect(function(){ client.setSteamId(99007199254740991); })
-        .toThrow(new Error('SteamId should be a string when larger than MAX_SAFE_INTEGER 9007199254740991'));
+      .toThrow(new Error('SteamId should be a string when larger than MAX_SAFE_INTEGER 9007199254740991'));
   });
 });

--- a/steam/Client.js
+++ b/steam/Client.js
@@ -74,7 +74,7 @@ module.exports = (function (undefined){
   Client.prototype.setSteamId = function setSteamId(value){
     // polyfill for less than es2015
     Number.isSafeInteger = Number.isSafeInteger || function (value) {
-      return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER;
+      return typeof value === 'number' && Math.abs(value) <= Number.MAX_SAFE_INTEGER;
     };
 
     if (typeof value === 'number' && ! Number.isSafeInteger(value)) {

--- a/steam/Client.js
+++ b/steam/Client.js
@@ -72,6 +72,15 @@ module.exports = (function (undefined){
   };
 
   Client.prototype.setSteamId = function setSteamId(value){
+    // polyfill for less than es2015
+    Number.isSafeInteger = Number.isSafeInteger || function (value) {
+      return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER;
+    };
+
+    if (typeof value === 'number' && ! Number.isSafeInteger(value)) {
+      throw new Error('SteamId should be a string when larger than MAX_SAFE_INTEGER 9007199254740991');
+    }
+
     this.steamId = value;
   };
 


### PR DESCRIPTION
I came across this when I was testing this module for integration with some automation I'm working on. I pasted in the SteamID without really looking at it and didn't quote it.  When I ran it I was getting incorrect or empty results.

Since all the tests were passing I looked into it some more and found it was getting silently changed when converted to a string because it was larger than `MAX_SAFE_INTEGER`.

I added a check in `Client.setSteamId`  that will throw an error to prevent this and added a test to ClientSpec.
