### PR TITLE
Fix quering for details of non-existing app

### DIFF
--- a/steam/App.js
+++ b/steam/App.js
@@ -8,7 +8,7 @@ module.exports = (function(){
   function cleanApps(apps) {
     var cleanedApps = [];
     for( var appId in apps ){
-      if(apps[appId]){
+      if(apps[appId] && apps[appId].success){
         cleanedApps.push(new AppContainer(apps[appId].data));
       }
     }
@@ -42,7 +42,11 @@ module.exports = (function(){
 
     client.then(function(result){
       apps = cleanApps( result.data );
-      deferred.resolve(apps.length === 1 ? apps[0] : apps);
+      if( apps.length ) {
+        deferred.resolve(apps.length === 1 ? apps[0] : apps);
+      } else {
+        deferred.reject(result.data);
+      }
     })
     .fail(function(result){
       deferred.reject(result);


### PR DESCRIPTION
In case if an application with given id does not exist in Steam database, Steam API will return details object for each entry only with `success` property with `false` value which will fail [App instance creation](https://github.com/DPr00f/steam-api-node/blob/master/steam/App.js#L12) because of missing properties.